### PR TITLE
Push Success and Failure events back to Pinpoint PutEvents API

### DIFF
--- a/pinpointtwitter/app.py
+++ b/pinpointtwitter/app.py
@@ -59,8 +59,12 @@ def lambda_handler(event, context):
 
             # To utilize other Twitter APIs here see Twitters API documentation - https://developer.twitter.com/en/docs/basics/getting-started
 
-            custom_events_batch[endpoint_id] = create_success_custom_event(endpoint_id, event['CampaignId'], message)
-            # add a twitter success event to our batch
+            if 'errors' in result:
+                custom_events_batch[endpoint_id] = create_failure_custom_event(endpoint_id, event['CampaignId'], result['errors'])
+                # found errors, add a twitter failure event to our batch
+            else:
+                custom_events_batch[endpoint_id] = create_success_custom_event(endpoint_id, event['CampaignId'], message)
+                # add a twitter success event to our batch
 
         except Exception as e:
             print(e)
@@ -118,6 +122,7 @@ def create_failure_custom_event(endpoint_id, campaign_id, e):
         'Timestamp': datetime.datetime.now().isoformat(),
         'Attributes': {
             'campaign_id': campaign_id,
-            'error': repr(e)
+            'errors': repr(e)
         }
     }
+    return custom_event

--- a/template.yaml
+++ b/template.yaml
@@ -26,6 +26,12 @@ Resources:
     Properties:
       FunctionName: AmazonPinpointTwitterChannel
       CodeUri: pinpointtwitter/
+      Policies:
+        - Statement:
+          - Sid: PinpointPutEvents
+            Effect: Allow
+            Action: mobiletargeting:PutEvents
+            Resource: !Sub arn:${AWS::Partition}:mobiletargeting:${AWS::Region}:${AWS::AccountId}:*
       Handler: app.lambda_handler
       Runtime: python3.7
       Environment:


### PR DESCRIPTION
Just like we have for other channels, it is important to be able to track what users were sent a message and when and if the message was successful or not.  Added custom events: 
- twitter.success
- twitter.failure
These events would then be available in the Event Stream and the downstream reporting.